### PR TITLE
Support for PHP 7.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "~5.0"
     },

--- a/src/Constants/LogLevel.php
+++ b/src/Constants/LogLevel.php
@@ -10,10 +10,10 @@ class LogLevel
      * Example: A log level of 0 will disable logging entirely, while a log level of 2 will enable ERROR, WARN,
      * and TRACE.
      */
-    public static $NONE = 0;
-    public static $ERROR = 1;
-    public static $WARN = 2;
-    public static $INFO = 3;
-    public static $TRACE = 4;
-    public static $DEBUG = 5;
+    const NONE = 0;
+    const ERROR = 1;
+    const WARN = 2;
+    const INFO = 3;
+    const TRACE = 4;
+    const DEBUG = 5;
 }

--- a/src/Constants/LogLevel.php
+++ b/src/Constants/LogLevel.php
@@ -10,10 +10,10 @@ class LogLevel
      * Example: A log level of 0 will disable logging entirely, while a log level of 2 will enable ERROR, WARN,
      * and TRACE.
      */
-    public const NONE = 0;
-    public const ERROR = 1;
-    public const WARN = 2;
-    public const INFO = 3;
-    public const TRACE = 4;
-    public const DEBUG = 5;
+    public static $NONE = 0;
+    public static $ERROR = 1;
+    public static $WARN = 2;
+    public static $INFO = 3;
+    public static $TRACE = 4;
+    public static $DEBUG = 5;
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -21,7 +21,7 @@ return [
      * - ERROR  (1)
      * - NONE   (0)
      */
-    'log-level' => \Smcrow\SlackLog\Constants\LogLevel::DEBUG,
+    'log-level' => \Smcrow\SlackLog\Constants\LogLevel::$DEBUG,
 
     /**
      * The channel to send log messages to.

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -21,7 +21,7 @@ return [
      * - ERROR  (1)
      * - NONE   (0)
      */
-    'log-level' => \Smcrow\SlackLog\Constants\LogLevel::$DEBUG,
+    'log-level' => \Smcrow\SlackLog\Constants\LogLevel::DEBUG,
 
     /**
      * The channel to send log messages to.


### PR DESCRIPTION
This pull request adds support for PHP 7.0.*, in line with the relevant Laravel versions. It also locks the minimum version to 7.0.0 to ensure that install does not fail halfway through on machines that run a lower version of PHP

Resolves issue #4 

